### PR TITLE
Remove deprecation

### DIFF
--- a/src/IO/Util.php
+++ b/src/IO/Util.php
@@ -17,7 +17,7 @@ class Util
     public static function getImageInfo(ActionApi $api, string $filename, string $iiprop = null): array | false {
         $query = [
             "format" => "json",
-            "titles" => "File:${filename}",
+            "titles" => "File:$filename",
             "prop" => "imageinfo"
         ];
 

--- a/src/IO/Util.php
+++ b/src/IO/Util.php
@@ -52,7 +52,7 @@ class Util
             "November" => "نوفمبر",
             "December" => "ديسمبر"
         );
-        return $months[strftime("%B")] . " " . strftime("%Y");
+        return $months[date('F')] . " " . date('Y');
     }
     public static function PregReplace($Text, $Array = array()): string {
         foreach ($Array as $Row) {

--- a/src/Tasks/FeaturedContent.php
+++ b/src/Tasks/FeaturedContent.php
@@ -218,7 +218,7 @@ class FeaturedContent extends Task
                     str_replace("مراجعة الزملاء/", "", $name["page_title"]),
                 );
                 
-                $Page = $this->getPage("ويكيبيديا:مراجعة الزملاء/${NamePage}");
+                $Page = $this->getPage("ويكيبيديا:مراجعة الزملاء/$NamePage");
                 $TextPage = $Page->getRevisions()->getLatest()->getContent()->getData();
                 $_data = $this->getDataPage($NamePage);
                 $Comment = $this->getComment($TextPage);
@@ -234,7 +234,7 @@ class FeaturedContent extends Task
                 $Archive = new PeerReviewArchive($this->api, $this->services, $this->mysqli);
                 $Archive->Archive($NamePage);
                 } else {
-                    $this->log->info("A page ${NamePage} that is not older than two days.");
+                    $this->log->info("A page $NamePage that is not older than two days.");
                 }
             }
         }


### PR DESCRIPTION
Remove and replace deprecated functions:

- Using ${} in strings is deprecated.
- 'strftime' is deprecated.