### PR TITLE
[PeerReviewArchive] Reduce the maximum number of pages in an archive

### DIFF
--- a/src/Tasks/PeerReviewArchive.php
+++ b/src/Tasks/PeerReviewArchive.php
@@ -108,7 +108,7 @@ class PeerReviewArchive extends Task
                      }
                     $ArchivePage = $this->getPage("ويكيبيديا:مراجعة الزملاء/أرشيف ${num}");
                     $ArchivePageText = $ArchivePage->getRevisions()->getLatest()->getContent()->getData();
-                    if (preg_match_all("/\{\{متمز\|(.*)\}\}/", $ArchivePageText, $matches) < 15) {
+                    if (preg_match_all("/\{\{متمز\|(.*)\}\}/", $ArchivePageText, $matches) < 11) {
                         if (strpos($ArchivePageText, $YearMonth) !== false) {
                             $revision = new Revision(new Content("${ArchivePageText}\n{{متمز|$name}}"),$ArchivePage->getPageIdentifier());
                         } else {    


### PR DESCRIPTION
Reduce the maximum number of pages in the archive from 15 to 11. Because the number of templates included in the page and some templates are not displayed due to Post-expand include size.