### PR TITLE
Reorder weekly tasks

### DIFF
--- a/bin/weekly.sh
+++ b/bin/weekly.sh
@@ -1,2 +1,2 @@
-php ${HOME}/ArWiki/src/RunTask RemoveMissingFiles
 php ${HOME}/ArWiki/src/RunTask ReduceImages
+php ${HOME}/ArWiki/src/RunTask RemoveMissingFiles


### PR DESCRIPTION
For some reason the ReduceImages task is not running after the RemoveMissingFiles task is finished.