### PR TITLE
Refactor SQL queries to use linktarget for category links

### DIFF
--- a/assets/SQL/AllocatingStubs.sql
+++ b/assets/SQL/AllocatingStubs.sql
@@ -1,12 +1,16 @@
 SELECT
     REPLACE(p.page_title, "_", " ") AS title,
-    REPLACE(REPLACE(REPLACE(GROUP_CONCAT(cl2.cl_to), "_", " "),"بوابة ",""),"/مقالات متعلقة","") AS portals
+    REPLACE(REPLACE(REPLACE(GROUP_CONCAT(lt2.lt_title), "_", " "),"بوابة ",""),"/مقالات متعلقة","") AS portals
 FROM
     page AS p
 JOIN categorylinks AS cl1 ON p.page_id = cl1.cl_from
+JOIN linktarget AS lt1 ON cl1.cl_target_id = lt1.lt_id
 JOIN categorylinks AS cl2 ON p.page_id = cl2.cl_from
+JOIN linktarget AS lt2 ON cl2.cl_target_id = lt2.lt_id
 WHERE p.page_is_redirect = 0
 AND p.page_namespace = 0
-AND cl1.cl_to = "بذرة"
-AND cl2.cl_to LIKE "%/مقالات_متعلقة"
+AND lt1.lt_namespace = 14
+AND lt1.lt_title = "بذرة"
+AND lt2.lt_namespace = 14
+AND lt2.lt_title LIKE "%/مقالات_متعلقة"
 GROUP BY p.page_title

--- a/assets/SQL/GetPagesFromCategories.sql
+++ b/assets/SQL/GetPagesFromCategories.sql
@@ -3,5 +3,8 @@ SELECT
 FROM
     page
 JOIN
-categorylinks on page.page_id = categorylinks.cl_from
-WHERE cl_to like "{{Name}}";
+    categorylinks on page.page_id = categorylinks.cl_from
+JOIN
+    linktarget on categorylinks.cl_target_id = linktarget.lt_id
+WHERE linktarget.lt_namespace = 14
+    AND linktarget.lt_title like "{{Name}}";

--- a/assets/SQL/Non-free_images.sql
+++ b/assets/SQL/Non-free_images.sql
@@ -6,24 +6,30 @@ SELECT
 FROM image AS i
 JOIN page AS p ON p.page_title = i.img_name
 JOIN categorylinks AS cl ON p.page_id = cl.cl_from
+JOIN linktarget AS lt ON cl.cl_target_id = lt.lt_id
 WHERE i.img_width > 400
   AND i.img_height > 400
   AND i.img_name NOT LIKE "%.svg"
   AND i.img_name NOT LIKE "%.pdf"
   AND p.page_is_redirect = 0
   AND p.page_namespace = 6
-  AND cl.cl_to = "جميع_الملفات_غير_الحرة"
+  AND lt.lt_namespace = 14
+  AND lt.lt_title = "جميع_الملفات_غير_الحرة"
 AND NOT EXISTS (
     SELECT 1
     FROM page AS pp
     JOIN categorylinks AS cl2 ON pp.page_id = cl2.cl_from
+    JOIN linktarget AS lt2 ON cl2.cl_target_id = lt2.lt_id
     WHERE pp.page_title = i.img_name
-      AND cl2.cl_to = "ملفات_غير_حرة_موسومة_لعدم_تقليل_الدقة"
+      AND lt2.lt_namespace = 14
+      AND lt2.lt_title = "ملفات_غير_حرة_موسومة_لعدم_تقليل_الدقة"
 )
 AND NOT EXISTS (
     SELECT 1
     FROM page AS pp
     JOIN categorylinks AS cl3 ON pp.page_id = cl3.cl_from
+    JOIN linktarget AS lt3 ON cl3.cl_target_id = lt3.lt_id
     WHERE pp.page_title = i.img_name
-      AND cl3.cl_to = "ملفات_غير_حرة_بإصدارات_يتيمة"
+      AND lt3.lt_namespace = 14
+      AND lt3.lt_title = "ملفات_غير_حرة_بإصدارات_يتيمة"
 );

--- a/assets/SQL/PagesWithMissingFiles.sql
+++ b/assets/SQL/PagesWithMissingFiles.sql
@@ -3,11 +3,13 @@ SELECT
 FROM
     page AS p
 INNER JOIN categorylinks AS category ON p.page_id = category.cl_from
+INNER JOIN linktarget AS lt ON category.cl_target_id = lt.lt_id
 WHERE
     p.page_is_redirect = 0
     AND p.page_id in (SELECT fr_page_id FROM flaggedrevs WHERE fr_rev_id = page_latest)
     AND p.page_namespace = 0
-    AND category.cl_to = "صفحات_تحوي_وصلات_ملفات_معطوبة"
+    AND lt.lt_namespace = 14
+    AND lt.lt_title = "صفحات_تحوي_وصلات_ملفات_معطوبة"
 GROUP BY p.page_title
 LIMIT {{LIMIT}}
 OFFSET {{OFFSET}};


### PR DESCRIPTION
This pull request updates multiple SQL queries to reflect changes in the MediaWiki database schema related to category links. The deprecated `cl_to` column filtering has been replaced with `linktarget` joins filtering on `lt_namespace = 14` and `lt_title`. 

Queries updated:
- `AllocatingStubs.sql`
- `GetPagesFromCategories.sql`
- `Non-free_images.sql`
- `PagesWithMissingFiles.sql`
